### PR TITLE
v8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ export class AnyCollectionAdapter<T> implements DataAdapter<Set<T>> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: Set<T>): this { this.#value = value; return this; }
+  setValue(value: Set<T>): this { this.#value = value; return this; }
+  getValue(): Set<T> { return this.#value; }
   get value(): Set<T> {
     return this.#value;
   }
@@ -133,7 +134,8 @@ export class SetCollectionAdapter<T> implements DataAdapter<Set<T>> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: Set<T>): this { this.#value = value; return this; }
+  setValue(value: Set<T>): this { this.#value = value; return this; }
+  getValue(): Set<T> { return this.#value; }
   get value(): Set<T> {
     return this.#value;
   }
@@ -145,7 +147,6 @@ const setCollectionData = new SetCollectionData(false, SetCollectionAdapter, 1, 
 
 // SetCollectionAdapter<number> | undefined
 setCollectionData.adapter;
-
 ```
 
 ### `BaseData`
@@ -200,7 +201,8 @@ export class SetAdapter<E, T extends Set<E>> implements DataAdapter<T, false> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = value; return this; }
+  getValue(): T { return this.#value; }
+  setValue(value: T): this { this.#value = value; return this; }
   get value(): T {
     return this.#value;
   }
@@ -215,6 +217,33 @@ setData.adapter?.newMethod();
 // SetAdapter<unknown, Set<unknown>> | undefined
 setData.adapter
 
+// Create another adapter implementation of `DataAdapter` interface.
+export class CollectionAdapter<E, T = Set<E>, G extends E[] = E[]> implements DataAdapter<T> {
+  #value: T;
+  constructor(...elements: G) {
+    this.#value = new Set(elements) as T;
+  }
+  clear(): this { return this; }
+  destroy(): this { return this; }
+  lock(): this { return this; }
+  getValue(): T { return this.#value; }
+  setValue(value: T): this { this.#value = value; return this; }
+  get value(): T {
+    return this.#value;
+  }
+}
+
+// Create a new instance of `CollectionAdapter`.
+const collectionData = new TestBaseData(
+  false,
+  new Set([1, 2, 3]),
+  CollectionAdapter,
+  1, 2, 3
+);
+
+
+// DataAdapter<Set<number>, false> | undefined
+collectionData.adapter
 ```
 
 ### `DataCore`
@@ -255,7 +284,7 @@ const stringData = new StringData("Hello, world!");
 console.log(stringData.value); // ➝ Hello, world!
 
 // Update the value
-stringData.set("New value");
+stringData.setValue("New value");
 console.log(stringData.value); // ➝ New value
 
 // Destroy the value
@@ -285,7 +314,8 @@ export class RxDataAdapter<
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = this.#onSet(value); return this; }
+  setValue(value: T): this { this.#value = this.#onSet(value); return this; }
+  getValue(): T { return this.#value; }
   get value(): T {
     return this.#value;
   }
@@ -295,7 +325,7 @@ export class RxDataAdapter<
 const data = new Data(false, 'Initial value' as string, RxDataAdapter);
 
 data.adapter?.onSet(value => `Reactive: ${value}`);
-data.set('New value'); // logs: 'Reactive: New value'
+data.setValue('New value'); // logs: 'Reactive: New value'
 ```
 
 Example with asynchronous adapter.
@@ -318,7 +348,8 @@ export class AsyncAdapter<
   async clear(): Promise<this> { return this; }
   async destroy(): Promise<this> { return this; }
   lock(): this { return this; }
-  async set(value: T): Promise<this> { this.#value = value; return this; }
+  async setValue(value: T): Promise<this> { this.#value = value; return this; }
+  async getValue(): Promise<T> { return this.#value; }
   get value(): T {
     return this.#value;
   }
@@ -330,7 +361,6 @@ const asyncData = new Data(true, 'Initial async value' as string, AsyncAdapter);
 asyncData.adapter?.ready().then(value => {
   console.log('Async value:', value);
 });
-
 ```
 
 ## Immutability

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,7 @@
         "typescript-eslint": "^8.46.3"
       },
       "peerDependencies": {
-        "@typedly/callback": "^2.0.0",
-        "@typedly/data": "^3.0.0",
-        "@typedly/hooks": "^1.0.0",
-        "@typescript-package/hooks": "^1.0.0"
+        "@typedly/data": "^4.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -327,23 +324,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@typedly/callback": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@typedly/callback/-/callback-2.0.0.tgz",
-      "integrity": "sha512-gRxeDFOvmaENiYpoSBE5mbaCMorX2d1V1jCLe9N0WPJIg+lnczCwnK24zj7UiXvMprp5BYvgT+qauHTJdpkcxA==",
-      "funding": [
-        {
-          "type": "stripe",
-          "url": "https://donate.stripe.com/dR614hfDZcJE3wAcMM"
-        },
-        {
-          "type": "revolut",
-          "url": "https://checkout.revolut.com/pay/048b10a3-0e10-42c8-a917-e3e9cb4c8e29"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@typedly/constructor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@typedly/constructor/-/constructor-1.0.0.tgz",
@@ -362,9 +342,9 @@
       "peer": true
     },
     "node_modules/@typedly/data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@typedly/data/-/data-3.0.0.tgz",
-      "integrity": "sha512-ScUoMCm9pyX1VwrFmhT8Td/uffk8+hov3amCBhqCr5uVnsJJbbpmH/vgXcQin1E5EM1jddKLOlWvBOxdallR9Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@typedly/data/-/data-4.0.0.tgz",
+      "integrity": "sha512-k6Ol+4WgrN+RWKNQzfXX6Tn90XGTp1taPFCrFVoKNQ6JEK+DZzTODFx3eEBV2zX51BJ3wuLeUX6LB1VlNOTd0g==",
       "funding": [
         {
           "type": "stripe",
@@ -379,26 +359,6 @@
       "peer": true,
       "peerDependencies": {
         "@typedly/constructor": "^1.0.0"
-      }
-    },
-    "node_modules/@typedly/hooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@typedly/hooks/-/hooks-1.0.0.tgz",
-      "integrity": "sha512-VaeFnM9j06d7CBqOItt4WsepgWUP+oKb9XoS/Z1uqn4V6xXegidIj4ae5Od4GQhNahGxgaLOPb7epQ2n3eTXaQ==",
-      "funding": [
-        {
-          "type": "stripe",
-          "url": "https://donate.stripe.com/dR614hfDZcJE3wAcMM"
-        },
-        {
-          "type": "revolut",
-          "url": "https://checkout.revolut.com/pay/048b10a3-0e10-42c8-a917-e3e9cb4c8e29"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@typedly/callback": "^2.0.0"
       }
     },
     "node_modules/@types/estree": {
@@ -648,27 +608,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-package/hooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-package/hooks/-/hooks-1.0.0.tgz",
-      "integrity": "sha512-QbJAbs6PIeVRK0ThMjljJQ7zkET/6buS6FeUnr25kpt/8UyKCHZ+zofluCojg5kpgq25pfEhQbSNFqEA1KP9FA==",
-      "funding": [
-        {
-          "type": "stripe",
-          "url": "https://donate.stripe.com/dR614hfDZcJE3wAcMM"
-        },
-        {
-          "type": "individual",
-          "url": "https://checkout.revolut.com/pay/048b10a3-0e10-42c8-a917-e3e9cb4c8e29"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@typedly/callback": "^2.0.0",
-        "@typedly/hooks": "^1.0.0"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript-eslint": "^8.46.3"
   },
   "peerDependencies": {
-    "@typedly/data": "^3.0.0"
+    "@typedly/data": "^4.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm run pkg && npm run clean",

--- a/src/lib/adapter-data.example.ts
+++ b/src/lib/adapter-data.example.ts
@@ -22,7 +22,8 @@ export class AnyCollectionAdapter<T> implements DataAdapter<Set<T>> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: Set<T>): this { this.#value = value; return this; }
+  setValue(value: Set<T>): this { this.#value = value; return this; }
+  getValue(): Set<T> { return this.#value; }
   get value(): Set<T> {
     return this.#value;
   }
@@ -55,7 +56,8 @@ export class SetCollectionAdapter<T> implements DataAdapter<Set<T>> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: Set<T>): this { this.#value = value; return this; }
+  setValue(value: Set<T>): this { this.#value = value; return this; }
+  getValue(): Set<T> { return this.#value; }
   get value(): Set<T> {
     return this.#value;
   }

--- a/src/lib/base-data.abstract.ts
+++ b/src/lib/base-data.abstract.ts
@@ -74,9 +74,8 @@ export abstract class BaseData<
    */
   public override clear(): AsyncReturn<R, this> {
     return super.adapter
-      ? super.adapter.clear()
-      : (this.#value = undefined as unknown as T),
-      this as AsyncReturn<R, this>;
+      ? super.clear()
+      : ((this.#value = undefined as unknown as T), super.returnThis(this)) ;
   }
 
   /**
@@ -86,9 +85,8 @@ export abstract class BaseData<
    */
   public override destroy(): AsyncReturn<R, this> {
     return super.adapter
-      ? super.adapter.destroy()
-      : (this.#value = null as unknown as T),
-      this as AsyncReturn<R, this>;
+      ? super.destroy()
+      : ((this.#value = null as unknown as T), super.returnThis(this));
   }
 
   /**
@@ -97,11 +95,9 @@ export abstract class BaseData<
    * @param {T} value The data value of `T` to set.
    * @returns {AsyncReturn<R, this>} The `this` current instance.
    */
-  public override set(value: T): AsyncReturn<R, this> {
-    return super.validate(),
-      super.adapter
-        ? super.adapter.set(value)
-        : (this.#value = value),
-        this as AsyncReturn<R, this>;
+  public override setValue(value: T): AsyncReturn<R, this> {
+    return super.adapter
+        ? super.setValue(value)
+        : (super.validate(), (this.#value = value), super.returnThis(this));
   }
 }

--- a/src/lib/base-data.example.ts
+++ b/src/lib/base-data.example.ts
@@ -42,7 +42,8 @@ export class SetAdapter<E, T extends Set<E>> implements DataAdapter<T, false> {
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = value; return this; }
+  getValue(): T { return this.#value; }
+  setValue(value: T): this { this.#value = value; return this; }
   get value(): T {
     return this.#value;
   }
@@ -66,7 +67,8 @@ export class CollectionAdapter<E, T = Set<E>, G extends E[] = E[]> implements Da
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = value; return this; }
+  getValue(): T { return this.#value; }
+  setValue(value: T): this { this.#value = value; return this; }
   get value(): T {
     return this.#value;
   }

--- a/src/lib/data-core.abstract.ts
+++ b/src/lib/data-core.abstract.ts
@@ -93,6 +93,14 @@ export abstract class DataCore<T, Async extends boolean = false>
   public abstract destroy(): AsyncReturn<Async, this>;
 
   /**
+   * @description Gets the value either asynchronously or synchronously based on the `Async` generic type variable.
+   * @public
+   * @abstract
+   * @returns {AsyncReturn<Async, T>} 
+   */
+  public abstract getValue(): AsyncReturn<Async, T>;
+
+  /**
    * @inheritdoc
    * @public
    * @returns {this} 
@@ -111,7 +119,7 @@ export abstract class DataCore<T, Async extends boolean = false>
    * @param {...V} values The arbitrary values array of type `V`.
    * @returns {this} 
    */
-  public abstract set<V extends unknown[]>(...values: V): AsyncReturn<Async, this>;
+  public abstract setValue<V extends unknown[]>(...values: V): AsyncReturn<Async, this>;
 
   /**
    * @description Sets the value of `T` in arbitrary parameter.
@@ -120,7 +128,7 @@ export abstract class DataCore<T, Async extends boolean = false>
    * @param {...T[]} value Arbitrary number of values of type `T`.
    * @returns {this} 
    */
-  public abstract set(...value: T[]): AsyncReturn<Async, this>;
+  public abstract setValue(...value: T[]): AsyncReturn<Async, this>;
 
   /**
    * @description Sets the data value. Ensure `super.validate()` is called before invoking this method.
@@ -129,7 +137,7 @@ export abstract class DataCore<T, Async extends boolean = false>
    * @param {T} value The data value of `T` to set.
    * @returns {this} Returns `this` current instance.
    */
-  public abstract set(value: T): AsyncReturn<Async, this>;
+  public abstract setValue(value: T): AsyncReturn<Async, this>;
 
   /**
    * @description Returns an iterator for the data value.

--- a/src/lib/data.example.ts
+++ b/src/lib/data.example.ts
@@ -14,7 +14,7 @@ const stringData = new StringData("Hello, world!");
 console.log(stringData.value); // ➝ Hello, world!
 
 // Update the value
-stringData.set("New value");
+stringData.setValue("New value");
 console.log(stringData.value); // ➝ New value
 
 // Destroy the value
@@ -38,7 +38,8 @@ export class RxDataAdapter<
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = this.#onSet(value); return this; }
+  setValue(value: T): this { this.#value = this.#onSet(value); return this; }
+  getValue(): T { return this.#value; }
   get value(): T {
     return this.#value;
   }
@@ -48,7 +49,7 @@ export class RxDataAdapter<
 const data = new Data(false, 'Initial value' as string, RxDataAdapter);
 
 data.adapter?.onSet(value => `Reactive: ${value}`);
-data.set('New value'); // logs: 'Reactive: New value'
+data.setValue('New value'); // logs: 'Reactive: New value'
 
 export class SetAdapter<
   E = string | number,
@@ -64,7 +65,8 @@ export class SetAdapter<
   clear(): this { return this; }
   destroy(): this { return this; }
   lock(): this { return this; }
-  set(value: T): this { this.#value = value; return this; }
+  setValue(value: T): this { this.#value = value; return this; }
+  getValue(): T { return this.#value; }
   get value(): T {
     return this.#value;
   }
@@ -89,7 +91,8 @@ export class AsyncAdapter<
   async clear(): Promise<this> { return this; }
   async destroy(): Promise<this> { return this; }
   lock(): this { return this; }
-  async set(value: T): Promise<this> { this.#value = value; return this; }
+  async setValue(value: T): Promise<this> { this.#value = value; return this; }
+  async getValue(): Promise<T> { return this.#value; }
   get value(): T {
     return this.#value;
   }

--- a/src/test/data-core.spec.ts
+++ b/src/test/data-core.spec.ts
@@ -25,7 +25,11 @@ class TestDataCore<T extends object> extends DataCore<T> implements DataShape<T>
     return this;
   }
 
-  public override set(value: T): this {
+  public getValue(): T {
+    return this.#value;
+  }
+
+  public setValue(value: T): this {
     super.validate(); // inherited method from Immutability
     this.#value = value;
     return this;
@@ -49,7 +53,7 @@ describe('DataCore', () => {
 
   it('should set a new value', () => {
     const newValue = { bar: 'baz' };
-    instance.set(newValue);
+    instance.setValue(newValue);
     expect(instance.value).toEqual(newValue);
   });
 
@@ -95,8 +99,12 @@ export class Selector<T> extends DataCore<T> {
     return this;
   }
 
+  public getValue(): T {
+    return this.#value;
+  }
+
   // Implement the overload
-  public set(...value: T[]): this {
+  public setValue(...value: T[]): this {
     this.#value = value[0];
     return this;
 
@@ -104,6 +112,5 @@ export class Selector<T> extends DataCore<T> {
 }
 
 const selector = new Selector('1', '2', '3');
-
-selector.set('2', '4', '5');
+selector.setValue('2', '4', '5');
 

--- a/src/test/data.spec.ts
+++ b/src/test/data.spec.ts
@@ -18,7 +18,7 @@ export class ProfileFullName<T extends string> extends String implements ValueSh
 // Example subclass of Data
 export class StringData<Value extends string> extends Data<Value> {
   constructor(value: Value) {
-    super(value);
+    super(false, value);
   }
 }
 
@@ -55,7 +55,7 @@ describe('Data', () => {
   let instance: Data<object>;
 
   beforeEach(() => {
-    instance = new Data({ test: 'initial' } as object);
+    instance = new Data(false, { test: 'initial' } as object);
   });
 
   it('should have correct toStringTag', () => {

--- a/src/test/data.spec.ts
+++ b/src/test/data.spec.ts
@@ -37,7 +37,7 @@ console.debug(`data.value: `, data.value); // Output: Hello, world!
 console.debug(`data.tag:`, data.tag); // Output: Data
 
 // Update the value
-data.set("New value");
+data.setValue("New value");
 console.log(data.value); // Output: New value
 
 // Destroy the value
@@ -68,7 +68,7 @@ describe('Data', () => {
 
   it('should set a new value', () => {
     const newValue = { updated: true };
-    instance.set(newValue);
+    instance.setValue(newValue);
     expect(instance.value).toEqual(newValue);
   });
 
@@ -82,13 +82,13 @@ describe('Data', () => {
     // After destroy, instance.value will likely throw or be undefined.
     console.log(instance);
     expect(instance.value).toBeNull();
-    instance.set({ updated: true });
-    console.log(instance.set);
+    instance.setValue({ updated: true });
+    console.log(instance.setValue);
   });
 
   it('should return itself after set, clear, destroy', () => {
     const newValue = { x: 1 };
-    expect(instance.set(newValue)).toBe(instance);
+    expect(instance.setValue(newValue)).toBe(instance);
     expect(instance.clear()).toBe(instance);
     expect(instance.destroy()).toBe(instance);
   });
@@ -96,7 +96,7 @@ describe('Data', () => {
 
 // Array.
 // const t: readonly [number] = [27];
-// new Data([22]).set(t).value; // The `Readonly` in the `set` method param `value` allows to set.
+// new Data([22]).setValue(t).value; // The `Readonly` in the `setValue` method param `value` allows to set.
 
 // Readonly<Type> constructor
 // new Data([22]) // readonly [number]


### PR DESCRIPTION
- Rename `set()` to `setValue()` for clarity, and to avoid confusion with `set()` of key-value pair.
- Fix async mode to have returned types set as Promise<this> or this as appropriate.
- Add private #async to determine the returned methods result.
- Add `getValue()` method allowing asynchronous operation.